### PR TITLE
Sanitize commit messages

### DIFF
--- a/lib/git-history-view.coffee
+++ b/lib/git-history-view.coffee
@@ -41,7 +41,7 @@ class GitHistoryView extends SelectListView
         @_fetchFileHistory(stdout, exit)
 
     _fetchFileHistory: (stdout, exit) ->
-        format = "{\"hash\": \"%h\",\"author\": \"%an\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%s\"},"
+        format = "{\"hash\": \"%h\",\"author\": \"%an\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%f\"},"
 
         new BufferedProcess {
             command: "git",


### PR DESCRIPTION
I cherry-picked the existing fix, to respect authorship.

I think #11 broke the plugin for most people, so it's probably best to pull this and make a patch release, unless someone has a better solution.

Aside from double quotes, I think stuff like `}` can also screw up parsing, so instead of going through all those edge-cases maybe it's better to simply use the sanitized version?
